### PR TITLE
fix(license): use valid spdx identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "directories": {
         "example": "examples"
     },
-    "license": "MIT OR GPL-2.0",
+    "license": "MIT OR GPL-2.0-or-later",
     "repository": {
         "type": "git",
         "url": "git://github.com/infusion/Fraction.js.git"


### PR DESCRIPTION
The LICENSE file should also be updated to include the `GPL-2.0-or-later` license!