### PR TITLE
docs: Fix simple typo, denumerator -> denominator

### DIFF
--- a/bigfraction.js
+++ b/bigfraction.js
@@ -525,7 +525,7 @@
     },
   
     /**
-     * Gets the inverse of the fraction, means numerator and denumerator are exchanged
+     * Gets the inverse of the fraction, means numerator and denominator are exchanged
      *
      * Ex: new Fraction([-3, 4]).inverse() => -4 / 3
      **/

--- a/fraction.js
+++ b/fraction.js
@@ -574,7 +574,7 @@
     },
 
     /**
-     * Gets the inverse of the fraction, means numerator and denumerator are exchanged
+     * Gets the inverse of the fraction, means numerator and denominator are exchanged
      *
      * Ex: new Fraction([-3, 4]).inverse() => -4 / 3
      **/


### PR DESCRIPTION
There is a small typo in bigfraction.js, fraction.js.

Should read `denominator` rather than `denumerator`.

