### PR TITLE
Update package homepage link proto (HTTP to HTTPS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "fraction.js",
     "title": "fraction.js",
     "version": "4.0.13",
-    "homepage": "http://www.xarg.org/2014/03/rational-numbers-in-javascript/",
+    "homepage": "https://www.xarg.org/2014/03/rational-numbers-in-javascript/",
     "bugs": "https://github.com/infusion/Fraction.js/issues",
     "description": "A rational number library",
     "keywords": [


### PR DESCRIPTION
Extremely minor; reduces HTTP redirects during sessions that open the link.  A lot of NPM packages seem to link to their homepages via HTTPS (this is visible when using some of the NPM CLI tools), so this stood out and looks like a small change.