### PR TITLE
Fix license

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "directories": {
         "example": "examples"
     },
-    "license": "MIT OR GPL-2.0-or-later",
+    "license": "MIT",
     "repository": {
         "type": "git",
         "url": "git://github.com/infusion/Fraction.js.git"


### PR DESCRIPTION
Hi, cause license in `package.json` is "MIT OR GPL-2.0-or-later" instead of "MIT" Nexus IQ bans by "License-Copyleft" policy