### PR TITLE
Improve typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+package-lock.json

--- a/fraction.d.ts
+++ b/fraction.d.ts
@@ -11,6 +11,7 @@ type FractionConstructor = {
   (numerator: number, denominator: number): Fraction;
   (numbers: [number | string, number | string]): Fraction;
   (fraction: NumeratorDenominator): Fraction;
+  (firstValue: Fraction | number | string | [number | string, number | string] | NumeratorDenominator, secondValue?: number): Fraction;
 };
 
 export default class Fraction {
@@ -19,6 +20,7 @@ export default class Fraction {
   constructor (numerator: number, denominator: number);
   constructor (numbers: [number | string, number | string]);
   constructor (fraction: NumeratorDenominator);
+  constructor (firstValue: Fraction | number | string | [number | string, number | string] | NumeratorDenominator, secondValue?: number);
 
   s: number;
   n: number;

--- a/fraction.d.ts
+++ b/fraction.d.ts
@@ -9,7 +9,7 @@ type FractionConstructor = {
   (fraction: Fraction): Fraction;
   (num: number | string): Fraction;
   (numerator: number, denominator: number): Fraction;
-  (numbers: (number | string)[]): Fraction;
+  (numbers: [number | string, number | string]): Fraction;
   (fraction: NumeratorDenominator): Fraction;
 };
 
@@ -17,7 +17,7 @@ export default class Fraction {
   constructor (fraction: Fraction);
   constructor (num: number | string);
   constructor (numerator: number, denominator: number);
-  constructor (numbers: (number | string)[]);
+  constructor (numbers: [number | string, number | string]);
   constructor (fraction: NumeratorDenominator);
 
   s: number;


### PR DESCRIPTION
Hi, I've made a couple of changes:
- Using a tuple instead of an array type is better, since you only support two elements which correspond to the fraction's numerator and denominator
- I've added a generic constructor type, which allows you to pass arguments that correspond to multiple overloads in TypeScript
- I've also added the npm lockfile to .gitignore, since it's not tracked in source control