### PR TITLE
Add tests for bigfraction.js round()

### DIFF
--- a/tests/fraction.test.js
+++ b/tests/fraction.test.js
@@ -693,12 +693,34 @@ var tests = [{
   fn: "round",
   param: null,
   expect: "-1"
-},{
+}, {
   label: "round(-0)",
   set: -0,
   fn: "round",
   param: null,
   expect: "0"
+}, {
+	label: "round(big places)",
+	set: '10',
+	fn: "round",
+	param: '409652136432929109317120'.repeat(100),
+	expect: "-1"
+}, {
+	label: "round(big fraction)",
+	set: [
+	  '409652136432929109317120'.repeat(100), 
+	  '63723676445298091081155'.repeat(100)
+	],
+	fn: "round",
+	param: null,
+	expect: "6428570341270001560623330590225448467479093479780591305451264291405695842465355472558570608574213642"
+}, {
+	label: "round(big numerator)",
+	set: ['409652136432929109317'.repeat(100), 
+  10],
+	fn: "round",
+	param: null,
+	expect: "-1"
 }, {
   label: "17402216385200408/5539306332998545",
   set: [17402216385200408, 5539306332998545],


### PR DESCRIPTION
I've added 3 tests:

1. One with a big numerator, previously complained about `Infinity`, now ok :heavy_check_mark: 
2. One with big numerator and denominator, previously complained about `NaN` (due to attempted division of `Infinity`s), now ok :heavy_check_mark: 
3. One with a big `places`, which is now failing :negative_squared_cross_mark:  Not sure whether supporting BigInt `places` is a reasonable use case :sweat_smile: 